### PR TITLE
Update branch name logic for ECR image tag

### DIFF
--- a/.github/workflows/build-aws.yml
+++ b/.github/workflows/build-aws.yml
@@ -51,12 +51,13 @@ jobs:
       - name: Derive the branchname for ECR tag (replace '/' with '_')
         id: nice_branchname
         run: |
-          # Use REF to get branch name if a merge, else use BASE_REF
-          if [[ "${{ github.ref_name }}" == "refs/heads"* ]]
+          # Use base_ref if PR
+          if [[ "${{ github.ref_name }}" == *"/merge" ]]
           then
-              BRANCH_NAME=$(echo "${{ github.ref_name }}" | cut --complement -c 1-11)
-          else
               BRANCH_NAME="${{ github.base_ref }}"
+          # Use ref_name if merge
+          else
+              BRANCH_NAME="${{ github.ref_name }}"
           fi
           echo "NICE_BRANCHNAME=$(echo "$BRANCH_NAME" | tr '/' '_')" >> "$GITHUB_OUTPUT"
         shell: bash


### PR DESCRIPTION
The logic for deriving the "base branch" to use for ECR tagged images was broken.

I've tested this updated logic with a PR against `master` in `dss-ecosystem` (pointing to the workflow in this PR's branch): https://github.com/OpenMPDK/dss-ecosystem/actions/runs/4672724845

As well as a push (new branch creation - `stable/v1.0-deleteme`): https://github.com/OpenMPDK/dss-ecosystem/actions/runs/4672771080

In both cases - CodeBuild correctly chose the correct image tag name:
* `dss-build_master`
* `dss-build_stable_v1.0-deleteme`