### PR TITLE
Update defaults to run Gitlab pipeline on push to feature branch

### DIFF
--- a/.gitlab/defaults.yml
+++ b/.gitlab/defaults.yml
@@ -13,13 +13,13 @@
         BRANCH_NAME: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
         SONAR_BRANCH: ''
     - if: $CI_COMMIT_BRANCH == "master" && $CI_PIPELINE_SOURCE == "push"
-    - if: $CI_COMMIT_BRANCH =~ /^stable\/.*/ && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH =~ /^(stable|feature)\/.*/ && $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
   push_only:
     - if: $CI_COMMIT_BRANCH == "master" && $CI_PIPELINE_SOURCE == "push"
-    - if: $CI_COMMIT_BRANCH =~ /^stable\/.*/ && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH =~ /^(stable|feature)\/.*/ && $CI_PIPELINE_SOURCE == "push"
   scheduled_sync:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $SCHEDULE_TYPE == "sync"
 


### PR DESCRIPTION
Fix issue where gitlab pipeline is not running on push to `feature`.

Minor regression.

The filter now matches how it is in other repos which have not yet been migrated to pull defaults from `DSS` (example: `dss-ecosystem`)
