### PR TITLE
Fix docker build scripts and docker dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Build all of the DSS artifacts and its dependency artifacts using one script:
 Optionally, build only the dependencies artifacts:
 
 ```bash
-./scripts/docker/build_gcc.sh
 ./scripts/docker/build_aws-sdk.sh
 ./scripts/docker/build_kernel.sh
 ./scripts/docker/build_mlnx-tools.sh
@@ -85,25 +84,22 @@ sudo yum install bc bison boost-devel cmake cmake3 CUnit-devel devtoolset-11 dpk
 sudo python3 -m pip install pybind11 gcovr==5.0
 ```
 
-**NOTE: User-built GCC and AWS-SDK-CPP RPMs must be installed on the build machine.**
+**NOTE: User-built AWS-SDK-CPP RPM must be installed on the build machine.**
 
 On initial build:
 
-1. Build GCC: `./scripts/build_gcc.sh`
-2. Install the resulting GCC RPM: `sudo yum install ./dss-ansible/artifacts/dss-gcc510*.rpm -y`
-3. Build AWS-SDK-CPP: `./scripts/build_aws-sdk.sh`
-4. Install the resulting AWS-SDK-CPP RPM: `sudo yum install ./dss-ansible/artifacts/aws-sdk-cpp-*.rpm -y`
-5. Run the `build_all.sh` script: `./scripts/build_all.sh`
+1. Build AWS-SDK-CPP: `./scripts/build_aws-sdk.sh`
+2. Install the resulting AWS-SDK-CPP RPM: `sudo yum install ./dss-ansible/artifacts/aws-sdk-cpp-*.rpm -y`
+3. Run the `build_all.sh` script: `./scripts/build_all.sh`
 
-Once the GCC and AWS RPMs are installed, only the `build_all.sh` script needs to be run on subsequent builds.
+Once the AWS RPM is installed, only the `build_all.sh` script needs to be run on subsequent builds.
 
-Dependency artifacts for GCC, kernel, aws-sdk-cpp, and mlnx-tools are staged under `rpmbuilder` and `workspace` directories of your home directory by default. By leaving them in-place, re-build of these upstream components will be skipped on subsequent builds.
+Dependency artifacts for kernel, aws-sdk-cpp, and mlnx-tools are staged under `rpmbuilder` and `workspace` directories of your home directory by default. By leaving them in-place, re-build of these upstream components will be skipped on subsequent builds.
 
 ### Optional: Build individual components
 
 DSS Dependency build scripts:
 
-- Build GCC: `./scripts/build_gcc.sh`
 - Build aws-sdk-cpp: `./scripts/build_aws-sdk.sh`
 - Build kernel: `./scripts/build_kernel.sh`
 - Build mlnx-tools: `./scripts/build_mlnx-tools.sh`

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -38,7 +38,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "$SCRIPT_DIR/utils.sh"
 
 # Build dependency artificats
-"$SCRIPT_DIR/build_gcc.sh"
 "$SCRIPT_DIR/build_aws-sdk.sh"
 "$SCRIPT_DIR/build_kernel.sh"
 "$SCRIPT_DIR/build_mlnx-tools.sh"

--- a/scripts/docker/DSS.Dockerfile
+++ b/scripts/docker/DSS.Dockerfile
@@ -65,7 +65,7 @@ RUN set -eux \
         "ansible>=2.9,<2.10" \
         ansible-lint==5.3.2 \
         gcovr==5.0 \
-        pybind11 \
+	pybind11==2.11.1 \
         pycodestyle==2.8.0 \
         shellcheck-py==0.8.0.3 \
         yamllint==1.26.3 && \

--- a/scripts/docker/DSS.Dockerfile
+++ b/scripts/docker/DSS.Dockerfile
@@ -2,7 +2,6 @@ FROM centos:centos7.8.2003
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
-COPY dss-ansible/artifacts/dss-gcc510-*.rpm ./
 COPY dss-ansible/artifacts/aws-sdk-cpp-*.rpm ./
 RUN set -eux \
     && yum install -y \
@@ -50,7 +49,6 @@ RUN set -eux \
         tbb-devel \
         wget \
         zlib-devel \
-        /dss-gcc510*.rpm \
         /aws-sdk-cpp*.rpm && \
     rm -f ./*.rpm && \
     yum clean all && \

--- a/scripts/docker/build_all.sh
+++ b/scripts/docker/build_all.sh
@@ -7,7 +7,6 @@ DOCKER_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "$DOCKER_DIR/../utils.sh"
 
 # DSS Dependencies
-"$DOCKER_DIR"/build_gcc.sh
 "$DOCKER_DIR"/build_aws-sdk.sh
 "$DOCKER_DIR"/build_kernel.sh
 "$DOCKER_DIR"/build_mlnx-tools.sh

--- a/scripts/docker/build_dss-client.sh
+++ b/scripts/docker/build_dss-client.sh
@@ -3,4 +3,4 @@ set -e
 
 # Build aws-sdk-cpp in Docker
 DOCKER_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-"$DOCKER_DIR"/build_docker.sh -c dss-client -d DSS -t dssbuild -a 'dss_client-*.tgz' -u
+"$DOCKER_DIR"/build_docker.sh -c dss-client -d DSS -t dssbuild -a 'dss_client-*.tgz'

--- a/scripts/docker/build_dss-sdk.sh
+++ b/scripts/docker/build_dss-sdk.sh
@@ -3,4 +3,4 @@ set -e
 
 # Build dss-sdk in Docker
 DOCKER_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-"$DOCKER_DIR"/build_docker.sh -c dss-sdk -d DSS -t dssbuild -a 'nkv-sdk-bin-*.tgz' -u
+"$DOCKER_DIR"/build_docker.sh -c dss-sdk -d DSS -t dssbuild -a 'nkv-sdk-bin-*.tgz nkv-target-*.tgz'

--- a/scripts/docker/build_minio.sh
+++ b/scripts/docker/build_minio.sh
@@ -3,4 +3,4 @@ set -e
 
 # Build dss-gcc in Docker
 DOCKER_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-"$DOCKER_DIR"/build_docker.sh -c minio -d DSS -t dssbuild -a 'dss-minio-bin-' -u
+"$DOCKER_DIR"/build_docker.sh -c minio -d DSS -t dssbuild -a 'dss-minio-bin-*'


### PR DESCRIPTION
- Fix broken build with newer docker versions (permissions related issues to root file system)
- Remove unneeded dependencies for DSS-GCC
- Fix build issue related to `pybind` dependency without fixed version
- Update README to reflect GCC is no longer needed to be built as a dependency 