### PR TITLE
Pass org var SONAR_SCANNER_URL to codebuild

### DIFF
--- a/.github/workflows/build-aws.yml
+++ b/.github/workflows/build-aws.yml
@@ -68,3 +68,6 @@ jobs:
           compute-type-override: ${{ inputs.compute-type-override }}
           buildspec-override: "./buildspec/${{ inputs.buildspec != '' && inputs.buildspec || format('{0}.yml', inputs.component) }}"
           image-override: "${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-1.amazonaws.com/${{ secrets.REPOSITORY_NAME }}:${{ inputs.image != '' && inputs.image || format('dss-build_{0}', steps.nice_branchname.outputs.NICE_BRANCHNAME) }}"
+          env-vars-for-codebuild: SONAR_SCANNER_URL
+        env:
+          SONAR_SCANNER_URL: ${{ vars.SONAR_SCANNER_URL }}


### PR DESCRIPTION
We need to have tighter control over what file is downloaded for the Sonar-Scanner zip file in our pipelines.

To make this easier, we will define an org-level env var `SONAR_SCANNER_URL` which will contain the URL to the x86 zip file.

This var needs to be passed to codebuild so that it can be downloaded in the pipeline.

The URL is not a secret, and it's ok to show up as plaintext in the logs.